### PR TITLE
Allow the use of '--network' container option

### DIFF
--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -11,7 +11,6 @@ using GitHub.Runner.Sdk;
 using GitHub.DistributedTask.Pipelines.ContextData;
 using GitHub.DistributedTask.Pipelines.ObjectTemplating;
 using GitHub.Runner.Worker.Container.ContainerHooks;
-using Microsoft.IdentityModel.Tokens;
 #if OS_WINDOWS // keep win specific imports around even through we don't support containers on win at the moment
 using System.ServiceProcess;
 using Microsoft.Win32;

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -167,7 +167,7 @@ namespace GitHub.Runner.Worker
             var removedNetworks = new HashSet<string>();
             foreach (var container in containers)
             {
-                if (!container.ContainerNetwork.IsNullOrEmpty() && !removedNetworks.Contains(container.ContainerNetwork))
+                if (!string.IsNullOrEmpty(container.ContainerNetwork) && !removedNetworks.Contains(container.ContainerNetwork))
                 {
                     // Remove the container network
                     await RemoveContainerNetworkAsync(executionContext, container.ContainerNetwork);

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -91,7 +91,7 @@ namespace GitHub.Runner.Worker
             executionContext.Output("##[endgroup]");
 
             // Network can be specified by user with --network option
-            string containerNetwork = container.ContainerNetwork;
+            string containerNetwork = containers.First().ContainerNetwork;
             if (string.IsNullOrEmpty(containerNetwork)) {
                 // Create local docker network for this job to avoid port conflict when multiple runners run on same machine.
                 // All containers within a job join the same network
@@ -165,7 +165,7 @@ namespace GitHub.Runner.Worker
                 await StopContainerAsync(executionContext, container);
             }
             var containerNetwork = containers.First().ContainerNetwork;
-            if containerNetwork.StartsWith("github_network_") {
+            if (containerNetwork.StartsWith("github_network_")) {
                 // Remove the container network if we created it ~ prefix github_network_
                 await RemoveContainerNetworkAsync(executionContext, containerNetwork);
             }

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -94,8 +94,10 @@ namespace GitHub.Runner.Worker
             foreach (var container in containers)
             {
                 string containerNetwork = null;
+                // Do not create a network if user specified --network within container options
                 if (!container.ContainerCreateOptions.Contains("--network"))
                 {
+                    // Create local docker network for this job to avoid port conflict when multiple runners run on same machine.
                     executionContext.Output("##[group]Create local container network");
                     containerNetwork = $"github_network_{Guid.NewGuid():N}";
 
@@ -166,9 +168,9 @@ namespace GitHub.Runner.Worker
             var removedNetworks = new HashSet<string>();
             foreach (var container in containers)
             {
-                if (!container.ContainerNetwork.IsNullOrEmpty() && 
-                    !removedNetworks.Contains(container.ContainerNetwork))
+                if (!container.ContainerNetwork.IsNullOrEmpty() && !removedNetworks.Contains(container.ContainerNetwork))
                 {
+                    // Remove the container network
                     await RemoveContainerNetworkAsync(executionContext, container.ContainerNetwork);
                     removedNetworks.Add(container.ContainerNetwork);
                 }


### PR DESCRIPTION
# Problem

User is not able to use `host` network type if for whatever reason that is what he wants (e.g. IPv6).

# Solution

Do not create a network if `--network` (e.g. `--network host`) is used under container options.